### PR TITLE
Fix cog loading in newer redbot v3.5

### DIFF
--- a/feedback/__init__.py
+++ b/feedback/__init__.py
@@ -1,5 +1,5 @@
 from .feedback import Feedback
 
 
-def setup(bot):
-  bot.add_cog(Feedback(bot))
+async def setup(bot):
+  await bot.add_cog(Feedback(bot))

--- a/selfassign/__init__.py
+++ b/selfassign/__init__.py
@@ -1,5 +1,5 @@
 from .selfassign import SelfAssign
 
 
-def setup(bot):
-    bot.add_cog(SelfAssign(bot))
+async def setup(bot):
+    await bot.add_cog(SelfAssign(bot))

--- a/webthing/__init__.py
+++ b/webthing/__init__.py
@@ -1,5 +1,5 @@
 from .webthing import WebThing
 
-def setup(bot):
+async def setup(bot):
     cog = WebThing(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)

--- a/weeedcog/__init__.py
+++ b/weeedcog/__init__.py
@@ -3,6 +3,6 @@ from redbot.core import data_manager
 from shutil import rmtree
 
 
-def setup(bot):
+async def setup(bot):
     cog = WeeedBot(bot)
-    bot.add_cog(cog)
+    await bot.add_cog(cog)


### PR DESCRIPTION
This fixes the issue with RedBot v3.5 where the cogs from this code repository were unable to load due to an awaitable call to `bot.add_cog` not being awaited.

This changes `def setup(bot)` to `async def setup(bot)` and `bot.add_cog(...)` to `await bot.add_cog(...)`, respectively.